### PR TITLE
Add document translation tab and backend

### DIFF
--- a/demo_app/demo_app.py
+++ b/demo_app/demo_app.py
@@ -2220,6 +2220,71 @@ with gr.Blocks(analytics_enabled=False) as di_proc_block:
             di_proc_output_md,
         ],
     )
+
+### Document Translation Example ###
+with gr.Blocks(analytics_enabled=False) as doc_translate_block:
+    def translate_doc_request(file: Optional[str]):
+        translated_text = ""
+        summary_text = ""
+        if file is None:
+            gr.Warning(
+                "Please select or upload a PDF file to translate."
+            )
+            return ("", "", translated_text, summary_text)
+        mime_type = mimetypes.guess_type(file)[0]
+        with open(file, "rb") as f:
+            data = f.read()
+            headers = {"Content-Type": mime_type}
+            status_code, time_taken, response = send_request(
+                route="translate_document",
+                data=data,
+                headers=headers,
+                force_json_content_type=True,
+            )
+        if isinstance(response, dict):
+            translated_text = response.get("translation", "")
+            summary_text = response.get("summary", "")
+        return status_code, time_taken, translated_text, summary_text
+
+    doc_translate_instructions = gr.Markdown(
+        "Upload a PDF document. The file will be translated to English and summarised below."
+    )
+    with gr.Row():
+        with gr.Column():
+            doc_translate_file_upload = gr.File(
+                label="Upload PDF", file_count="single", type="filepath"
+            )
+            doc_translate_input_thumbs = gr.Gallery(
+                label="File Preview", object_fit="contain", visible=True
+            )
+        with gr.Column():
+            with gr.Row():
+                doc_translate_status_code = gr.Textbox(
+                    label="Response Status Code", interactive=False
+                )
+                doc_translate_time_taken = gr.Textbox(
+                    label="Time Taken", interactive=False
+                )
+            doc_translate_translation = gr.Textbox(
+                label="Translated Text", lines=10
+            )
+            doc_translate_summary = gr.Textbox(label="Summary", lines=3)
+
+    doc_translate_file_upload.change(
+        fn=render_visual_media_input,
+        inputs=[doc_translate_file_upload],
+        outputs=[doc_translate_input_thumbs],
+    )
+    doc_translate_file_upload.change(
+        fn=translate_doc_request,
+        inputs=[doc_translate_file_upload],
+        outputs=[
+            doc_translate_status_code,
+            doc_translate_time_taken,
+            doc_translate_translation,
+            doc_translate_summary,
+        ],
+    )
     
 # Gradio tab for audio upload and transcript viewing
 
@@ -2452,6 +2517,8 @@ with gr.Blocks(
         pii_redaction_block.render()
     with gr.Tab("Key Information Extraction, Doc Intelligence (HTTP)"):
         di_llm_ext_names_block.render()
+    with gr.Tab("Document Translation (HTTP)"):
+        doc_translate_block.render()
     with gr.Tab("Audio Batch Processing (HTTP)"):
         audio_transcription_tab(blob_service_client)
     with gr.Tab("Video Processing"):

--- a/function_app/bp_translate_document.py
+++ b/function_app/bp_translate_document.py
@@ -1,0 +1,115 @@
+import json
+import logging
+import os
+
+import azure.functions as func
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+from dotenv import load_dotenv
+from openai import AzureOpenAI
+from pydantic import BaseModel, Field
+
+from src.helpers.data_loading import load_pymupdf_pdf
+from src.helpers.common import MeasureRunTime
+
+load_dotenv()
+
+bp_translate_document = func.Blueprint()
+FUNCTION_ROUTE = "translate_document"
+
+# Azure OpenAI client setup
+aoai_token_provider = get_bearer_token_provider(
+    DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+)
+AOAI_ENDPOINT = os.getenv("AOAI_ENDPOINT")
+AOAI_LLM_DEPLOYMENT = os.getenv("AOAI_LLM_DEPLOYMENT")
+
+aoai_client = AzureOpenAI(
+    azure_endpoint=AOAI_ENDPOINT,
+    azure_deployment=AOAI_LLM_DEPLOYMENT,
+    azure_ad_token_provider=aoai_token_provider,
+    api_version="2024-06-01",
+    timeout=90,
+    max_retries=2,
+)
+
+
+class FunctionResponseModel(BaseModel):
+    success: bool = Field(False)
+    translation: str | None = None
+    summary: str | None = None
+    func_time_taken_secs: float | None = None
+    error_text: str | None = None
+
+
+LLM_PROMPT = (
+    "Translate the following text into English. "
+    "Then provide a short summary in English in three sentences or less. "
+    "Respond in JSON with keys 'translation' and 'summary'."
+)
+
+
+@bp_translate_document.route(route=FUNCTION_ROUTE)
+def translate_document(req: func.HttpRequest) -> func.HttpResponse:
+    logging.info(
+        f"Python HTTP trigger function `{FUNCTION_ROUTE}` received a request."
+    )
+    output = FunctionResponseModel(success=False)
+    try:
+        func_timer = MeasureRunTime()
+        func_timer.start()
+
+        mime_type = req.headers.get("Content-Type")
+        if mime_type != "application/pdf":
+            return func.HttpResponse(
+                (
+                    "This function only supports a Content-Type of 'application/pdf'. "
+                    f"Supplied file is of type {mime_type}"
+                ),
+                status_code=400,
+            )
+
+        pdf_bytes = req.get_body()
+        if len(pdf_bytes) == 0:
+            return func.HttpResponse(
+                "Please provide a PDF in the request body.", status_code=400
+            )
+
+        pdf = load_pymupdf_pdf(pdf_bytes=pdf_bytes)
+        text = "\n".join(page.get_text() for page in pdf)
+
+        messages = [
+            {"role": "system", "content": LLM_PROMPT},
+            {"role": "user", "content": text},
+        ]
+
+        llm_res = aoai_client.chat.completions.create(
+            messages=messages, model=AOAI_LLM_DEPLOYMENT
+        )
+        llm_text = llm_res.choices[0].message.content
+
+        try:
+            llm_json = json.loads(llm_text)
+            output.translation = llm_json.get("translation")
+            output.summary = llm_json.get("summary")
+        except Exception:
+            output.error_text = "LLM response could not be parsed."
+            output.func_time_taken_secs = func_timer.stop()
+            logging.exception(output.error_text)
+            return func.HttpResponse(
+                body=output.model_dump_json(),
+                mimetype="application/json",
+                status_code=500,
+            )
+
+        output.success = True
+        output.func_time_taken_secs = func_timer.stop()
+        return func.HttpResponse(
+            body=output.model_dump_json(),
+            mimetype="application/json",
+            status_code=200,
+        )
+    except Exception:
+        logging.exception("An error occurred during processing.")
+        return func.HttpResponse(
+            "An error occurred during processing.", status_code=500
+        )

--- a/function_app/function_app.py
+++ b/function_app/function_app.py
@@ -57,6 +57,8 @@ IS_COSMOSDB_AVAILABLE = check_if_env_var_is_set("COSMOSDB_DATABASE_NAME") and ch
 if IS_AOAI_DEPLOYED:
     from bp_summarize_text import bp_summarize_text
     app.register_blueprint(bp_summarize_text)
+    from bp_translate_document import bp_translate_document
+    app.register_blueprint(bp_translate_document)
 if IS_DOC_INTEL_DEPLOYED and IS_AOAI_DEPLOYED:
     from bp_doc_intel_extract_city_names import bp_doc_intel_extract_city_names
     from bp_form_extraction_with_confidence import bp_form_extraction_with_confidence


### PR DESCRIPTION
## Summary
- support translating uploaded PDF documents and summarizing them
- register new translate_document function in the backend
- add a new Document Translation tab in the Gradio UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'haystack')*

------
https://chatgpt.com/codex/tasks/task_e_683f519575e8832881c80dd4da20865e